### PR TITLE
Update Readme for GitHub Sponsor Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ They are likely to want additional error checking and security before being used
 
 If you want to use these, you can either build the containers yourself or use the prebuilt ones on dockerhub.
 
-Want to support me? Sponsor me on [Github](darkflib) or paypal.me/darkflib
+Want to support me? Sponsor me on [GitHub](https://github.com/sponsors/Darkflib) or paypal.me/darkflib
 
 Custom builds are available on request, just open an issue.
 


### PR DESCRIPTION
GitHub usually is referenced with capital G & H. Also the link was previously broken since it's rendered as: https://github.com/Darkflib/microservices/blob/main/darkflib which doesn't exist.